### PR TITLE
As of 9.3.0 the Docker images no longer specify a user.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,4 +17,4 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=uv --chown=vscode: /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/


### PR DESCRIPTION
This is not needed anymore